### PR TITLE
Change mail.txt template from %user% to %USER%

### DIFF
--- a/lang/en/mail.txt
+++ b/lang/en/mail.txt
@@ -1,4 +1,4 @@
-Hi @user@
+Hi @USER@
 
 Someone tried to log in using your account. If that was you, please use
 the code below to confirm your login.


### PR DESCRIPTION
when the plugin sends the auth email, the variable %user% is not filled, it has to be %USER% to work (same issue as https://github.com/cosmocode/dokuwiki-plugin-twofactoremail/pull/1 )